### PR TITLE
refactor: update backend paths and imports

### DIFF
--- a/backend/datapp/main.py
+++ b/backend/datapp/main.py
@@ -9,8 +9,9 @@ from pathlib import Path
 from sqlalchemy import create_engine
 
 # ruta absoluta al db.sqlite3 (ajústala si corres desde otra carpeta)
-BASE_DIR = Path(__file__).resolve().parent.parent  # carpeta raíz del repo
-DB_PATH = BASE_DIR / "webapp" / "db.sqlite3"
+# Ahora BASE_DIR apunta a la raíz del repositorio
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+DB_PATH = BASE_DIR / "backend" / "webapp" / "db.sqlite3"
 
 engine = create_engine(f"sqlite:///{DB_PATH}")
 

--- a/backend/webapp/barapp/asgi.py
+++ b/backend/webapp/barapp/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'barapp.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.webapp.barapp.settings')
 
 application = get_asgi_application()

--- a/backend/webapp/barapp/settings.py
+++ b/backend/webapp/barapp/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'gestion',
+    'backend.webapp.gestion',
 ]
 
 MIDDLEWARE = [
@@ -50,7 +50,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = 'barapp.urls'
+ROOT_URLCONF = 'backend.webapp.barapp.urls'
 
 TEMPLATES = [
     {
@@ -67,7 +67,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'barapp.wsgi.application'
+WSGI_APPLICATION = 'backend.webapp.barapp.wsgi.application'
 
 
 # Database

--- a/backend/webapp/barapp/urls.py
+++ b/backend/webapp/barapp/urls.py
@@ -19,5 +19,5 @@ from django.urls import path,include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include('gestion.urls')),
+    path('', include('backend.webapp.gestion.urls')),
 ]

--- a/backend/webapp/barapp/wsgi.py
+++ b/backend/webapp/barapp/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'barapp.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.webapp.barapp.settings')
 
 application = get_wsgi_application()

--- a/backend/webapp/gestion/analytics/utils.py
+++ b/backend/webapp/gestion/analytics/utils.py
@@ -1,5 +1,5 @@
 # analytics/utils.py
-from gestion.models import DetalleFactura
+from backend.webapp.gestion.models import DetalleFactura
 from django.db.models import Sum
 from django.db.models.functions import TruncDay, TruncMonth
 

--- a/backend/webapp/gestion/apps.py
+++ b/backend/webapp/gestion/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class GestionConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'gestion'
+    name = 'backend.webapp.gestion'

--- a/backend/webapp/gestion/views.py
+++ b/backend/webapp/gestion/views.py
@@ -1,5 +1,17 @@
 from django.shortcuts import render, redirect, get_object_or_404
-from gestion.models import Compra, DetalleCompra, Producto, Proveedor, ConfiguracionFactura, Factura, DetalleFactura, Cliente, Empleado, DetalleImpuesto, TipoPago
+from backend.webapp.gestion.models import (
+    Compra,
+    DetalleCompra,
+    Producto,
+    Proveedor,
+    ConfiguracionFactura,
+    Factura,
+    DetalleFactura,
+    Cliente,
+    Empleado,
+    DetalleImpuesto,
+    TipoPago,
+)
 from decimal import Decimal
 from django.db import transaction
 from django.utils import timezone
@@ -9,7 +21,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.http import HttpResponse
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
-from gestion.analytics.utils import ventas_por_dia, ventas_por_mes
+from backend.webapp.gestion.analytics.utils import ventas_por_dia, ventas_por_mes
 from django.db.models import Sum
 
 def login_view(request):

--- a/backend/webapp/manage.py
+++ b/backend/webapp/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'barapp.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.webapp.barapp.settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/backend/webapp/seed_sqlite.py
+++ b/backend/webapp/seed_sqlite.py
@@ -5,13 +5,13 @@ import datetime
 from decimal import Decimal
 
 import django
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "barapp.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.webapp.barapp.settings")
 django.setup()
 
 from django.db import transaction, connection
 from django.utils import timezone
 
-from gestion.models import (
+from backend.webapp.gestion.models import (
     DetalleImpuesto, Producto, Empleado, Cliente, TipoPago,
     Factura, DetalleFactura, ConfiguracionFactura
 )


### PR DESCRIPTION
## Summary
- adjust datapp scripts to new sqlite location
- namespace webapp imports under backend package

## Testing
- `PYTHONPATH=. python backend/webapp/manage.py test`
- `python -m py_compile backend/datapp/main.py backend/webapp/seed_sqlite.py backend/webapp/manage.py backend/webapp/barapp/asgi.py backend/webapp/barapp/wsgi.py backend/webapp/barapp/settings.py backend/webapp/barapp/urls.py backend/webapp/gestion/analytics/utils.py backend/webapp/gestion/apps.py backend/webapp/gestion/views.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9bc2324832b9d370e406f324ec3