### PR TITLE
feat: add CLI to launch dashboard or server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,33 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from backend.datapp.dashboard import run_dashboard
+
+
+def run_django() -> None:
+    """Run the Django development server."""
+    manage_py = Path(__file__).resolve().parent / "backend" / "webapp" / "manage.py"
+    subprocess.run([sys.executable, str(manage_py), "runserver"], check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="CLI para levantar el dashboard de Streamlit o el servidor Django"
+    )
+    parser.add_argument(
+        "command",
+        choices=["dashboard", "server"],
+        help="Selecciona 'dashboard' para Streamlit o 'server' para Django",
+    )
+    args = parser.parse_args()
+
+    if args.command == "dashboard":
+        run_dashboard()
+    else:
+        run_django()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add root CLI to choose between Streamlit dashboard or Django server

## Testing
- `python -m py_compile main.py`
- `python main.py -h`
- `python main.py dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68b8dd1f8a5c832b8e9a5c9c262ddc65