### PR TITLE
Fix path references and update run instructions

### DIFF
--- a/How_to_run.txt
+++ b/How_to_run.txt
@@ -1,4 +1,4 @@
-cd POS-Radiocity-main
+cd Arquitectura_de_Software
 python -m venv .venv
 # Activar entorno
 # Windows:
@@ -9,9 +9,11 @@ source .venv/bin/activate
 
 pip install -r requirements.txt
 
-cd webapp
+cd backend
 
 python datapp/populate_db.py
+
+cd webapp
 
 python manage.py migrate
 python manage.py runserver

--- a/backend/webapp/barapp/settings.py
+++ b/backend/webapp/barapp/settings.py
@@ -77,7 +77,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         # BASE_DIR = .../webapp/barapp  → el db.sqlite3 está en .../webapp
-        'NAME': (Path(__file__).resolve().parent.parent.parent / 'db.sqlite3'),
+        'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
 


### PR DESCRIPTION
## Summary
- Correct database path in Django settings to rely on `BASE_DIR`
- Update run instructions to use current repository structure and remove obsolete path

## Testing
- `rg "POS-Radiocity-main" -n`
- `python -m py_compile main.py backend/datapp/dashboard.py backend/webapp/barapp/settings.py`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b8e93bbadc832ba8a7505ecd11a038