### PR TITLE
Add CLI flag for dashboard and Django server

### DIFF
--- a/Proyecto/How_to_run.txt
+++ b/Proyecto/How_to_run.txt
@@ -19,3 +19,9 @@ python manage.py migrate
 python manage.py runserver
 
 http://127.0.0.1:8000/admin # en el navegador
+
+# Alternativamente, puedes usar el script principal y elegir
+# entre el dashboard de Streamlit o el servidor Django:
+
+python ../main.py --app dashboard  # Levanta el dashboard
+python ../main.py --app server     # Levanta el servidor Django

--- a/Proyecto/main.py
+++ b/Proyecto/main.py
@@ -14,16 +14,20 @@ def run_django() -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="CLI para levantar el dashboard de Streamlit o el servidor Django"
+        description="CLI para levantar el dashboard de Streamlit o el servidor Django",
     )
     parser.add_argument(
-        "command",
+        "--app",
         choices=["dashboard", "server"],
-        help="Selecciona 'dashboard' para Streamlit o 'server' para Django",
+        default="dashboard",
+        help=(
+            "Elige 'dashboard' para Streamlit (por defecto) "
+            "o 'server' para Django"
+        ),
     )
     args = parser.parse_args()
 
-    if args.command == "dashboard":
+    if args.app == "dashboard":
         run_dashboard()
     else:
         run_django()


### PR DESCRIPTION
## Summary
- add optional --app flag to choose between Streamlit dashboard and Django server
- document new main entry point usage in How_to_run.txt

## Testing
- `python Proyecto/main.py --help`
- `python -m py_compile Proyecto/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8f2a694d0832b9d59ce0ab1c0c754